### PR TITLE
Restrict valid profile names and implement associated unit tests.

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -178,7 +178,11 @@ def add_profile(ctx, app_state, profile):
     else:
         raise click.ClickException(f"Profile with name '{profile}' already exists.")
 
-    new_profile = Profile(name=profile)
+    try:
+        new_profile = Profile(name=profile)
+    except ValueError as error:  # invalid profile name
+        raise click.ClickException(error)
+
     app_state.config.profiles.append(new_profile)
     app_state.config.save(_application_config_path())
     click.echo(f"Added profile '{profile}'.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,15 +54,15 @@ def test_show_profile():
 
 def test_add_remove_profile():
     runner: CliRunner = CliRunner()
-    result: Result = runner.invoke(cli.cli, ["profiles", "add", "new_profile"])
-    assert "Added profile 'new_profile'." in result.output
+    result: Result = runner.invoke(cli.cli, ["profiles", "add", "new-profile"])
+    assert "Added profile 'new-profile'." in result.output
     result: Result = runner.invoke(cli.cli, ["profiles", "list"])
-    assert "new_profile" in result.output
-    result: Result = runner.invoke(cli.cli, ["profiles", "show", "new_profile"])
+    assert "new-profile" in result.output
+    result: Result = runner.invoke(cli.cli, ["profiles", "show", "new-profile"])
     assert result.exit_code == 0
     result: Result = runner.invoke(
-        cli.cli, ["profiles", "remove", "new_profile"], input="y\n"
+        cli.cli, ["profiles", "remove", "new-profile"], input="y\n"
     )
     assert result.exit_code == 0
     result: Result = runner.invoke(cli.cli, ["profiles", "list"])
-    assert "new_profile" not in result.output
+    assert "new-profile" not in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,10 @@ import pytest
 
 from aiidalab_launch.core import AiidaLabInstance, Config, Profile
 
+VALID_PROFILE_NAMES = ["abc", "Abc", "aBC", "a0", "a-a", "a-0"]
+
+INVALID_PROFILE_NAMES = ["", ".a", "a_a", "_a"]
+
 
 @pytest.fixture
 def profile():
@@ -40,6 +44,17 @@ def instance(docker_client, profile):
 
 def test_profile_init(profile):
     pass
+
+
+@pytest.mark.parametrize("name", VALID_PROFILE_NAMES)
+def test_profile_init_valid_names(profile, name):
+    assert replace(profile, name=name).name == name
+
+
+@pytest.mark.parametrize("name", INVALID_PROFILE_NAMES)
+def test_profile_init_invalid_names(profile, name):
+    with pytest.raises(ValueError):
+        replace(profile, name=name)
 
 
 def test_profile_equality(profile):


### PR DESCRIPTION
Since the profile name is used as basis for the docker container name it
must be restricted to values valid for containers names. While that
definition might change, the conservative restrictions imposed with this
change set should protect us against any surprises in that regard for
now.

In addition, we do not allow underscores since this might interefere
with the ability to change the tool implementation to use docker-compose
in the future.

Fixes #36.