### PR TITLE
Support HTTPS connection to Jupyter notebook

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -415,9 +415,11 @@ async def _async_start(
                 )
             except RuntimeError:
                 raise click.ClickException(
-                    "The AiiDAlab instance failed to start. Consider to inspect "
-                    "the container output logs by increasing the output "
-                    "verbosity with 'aiidalab-launch -vvv start'."
+                    "The AiiDAlab instance failed to start. You can inspect "
+                    "the container output logs with "
+                    f"'aiidalab-launch logs -p {instance.profile.name}' "
+                    "and increase the output verbosity with "
+                    "'aiidalab-launch -vvv start'."
                 )
             LOGGER.debug("Preparing startup message.")
             msg_startup = (


### PR DESCRIPTION
Basic aiidalab container comes with HTTP, but users might want to add HTTPS.
Here we just modify the code that tries to connect to Jupyter Notebook to determine whether it is ready.

I am currently playing with HTTPS for local development in our Docker image built on top of AiiDAlab-docker-stack, see https://github.com/danielhollas/aiidalab-ispg-docker-stack/pull/6 if that is of interest.

**TODO**: 
- [ ] Tests. Seems like it would be tricky to test this properly, we would somehow need to patch the Jupyter notebook in a  running container? Not sure it's worth investing too much time. In any case, to enable HTTPS, one simply needs to pass the key and certificate to `jupyter-notebook` in `/opt/start-notebook.sh`, see the PR linked above.
- [x] When the start command finishes, we still print http url, and if user tries to open the browser directly from cmdline it will open http and fail. I didn't figure out how to improve this since the polling function is an async `@staticmethod` so I did not not how to cleanly pass info from it without larger refactor. 