### PR TITLE
Hide stacktrace unless verbose mode is enabled

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -68,15 +68,15 @@ LOGGING_LEVELS = {
 pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
-def exception_handler(exception_type, exception, traceback):  # noqa: U100
+def exception_handler(exception_type, exception, _):
     click.echo(f"Unexpected {exception_type.__name__}: {exception}", err=True)
     click.echo(
-        "Use verbose mode `aiidalab-launch --verbose` to see full stacktrace", err=True
+        "Use verbose mode `aiidalab-launch --verbose` to see full stack trace", err=True
     )
 
 
 def with_profile(cmd):
-    def callback(ctx, param, value):  # noqa: U100
+    def callback(ctx, _, value):
         app_state = ctx.ensure_object(ApplicationState)
         name = value or app_state.config.default_profile
         LOGGER.info(f"Using profile: {name}")
@@ -108,7 +108,7 @@ def cli(app_state, verbose):
             err=True,
         )
 
-    # Hide stack traces by default
+    # Hide stack trace by default.
     if verbose == 0:
         sys.excepthook = exception_handler
 

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -68,7 +68,7 @@ LOGGING_LEVELS = {
 pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
-def exception_handler(exception_type, exception, traceback):  # noqa 100
+def exception_handler(exception_type, exception, traceback):  # noqa: U100
     click.echo(f"Unexpected {exception_type.__name__}: {exception}", err=True)
     click.echo(
         "Use verbose mode `aiidalab-launch --verbose` to see full stack trace", err=True
@@ -76,7 +76,7 @@ def exception_handler(exception_type, exception, traceback):  # noqa 100
 
 
 def with_profile(cmd):
-    def callback(ctx, param, value):  # noqa 100
+    def callback(ctx, param, value):  # noqa: U100
         app_state = ctx.ensure_object(ApplicationState)
         name = value or app_state.config.default_profile
         LOGGER.info(f"Using profile: {name}")

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -69,8 +69,10 @@ pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
 def exception_handler(exception_type, exception, traceback):  # noqa: U100
-    print(f"Unexpected {exception_type.__name__}: {exception}")
-    print("Use verbose mode `aiidalab-launch --verbose` to see full stacktrace")
+    click.echo(f"Unexpected {exception_type.__name__}: {exception}", err=True)
+    click.echo(
+        "Use verbose mode `aiidalab-launch --verbose` to see full stacktrace", err=True
+    )
 
 
 def with_profile(cmd):

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -68,7 +68,7 @@ LOGGING_LEVELS = {
 pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
-def exception_handler(exception_type, exception, _):
+def exception_handler(exception_type, exception, traceback):  # noqa 100
     click.echo(f"Unexpected {exception_type.__name__}: {exception}", err=True)
     click.echo(
         "Use verbose mode `aiidalab-launch --verbose` to see full stack trace", err=True
@@ -76,7 +76,7 @@ def exception_handler(exception_type, exception, _):
 
 
 def with_profile(cmd):
-    def callback(ctx, _, value):
+    def callback(ctx, param, value):  # noqa 100
         app_state = ctx.ensure_object(ApplicationState)
         name = value or app_state.config.default_profile
         LOGGER.info(f"Using profile: {name}")

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -8,6 +8,7 @@ import asyncio
 import getpass
 import logging
 import socket
+import sys
 from pathlib import Path
 from textwrap import wrap
 
@@ -67,6 +68,11 @@ LOGGING_LEVELS = {
 pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
+def exception_handler(exception_type, exception, traceback):  # noqa: U100
+    print(f"Unexpected {exception_type.__name__}: {exception}")
+    print("Use verbose mode `aiidalab-launch --verbose` to see full stacktrace")
+
+
 def with_profile(cmd):
     def callback(ctx, param, value):  # noqa: U100
         app_state = ctx.ensure_object(ApplicationState)
@@ -99,6 +105,10 @@ def cli(app_state, verbose):
             fg="yellow",
             err=True,
         )
+
+    # Hide stack traces by default
+    if verbose == 0:
+        sys.excepthook = exception_handler
 
     LOGGER.info(f"Configuration file path: {app_state.config_path}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,10 +51,10 @@ def test_version_verbose_logging():
     assert "Verbose logging is enabled." in result.output.strip()
 
 
-def test_hidden_stacktrace():
+def test_invalid_profile_name_throws():
     """
-    Arrange/Act: Run `profiles edit invalid` subcommand.
-    Assert:  The output does not contain stacktrace.
+    Arrange/Act: Run `profiles show invalid` subcommand.
+    Assert:  The command throws an exception due to invalid profile name.
     """
     runner: CliRunner = CliRunner()
     with pytest.raises(ValueError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,23 @@ def test_version_verbose_logging():
     assert "Verbose logging is enabled." in result.output.strip()
 
 
+def test_hidden_stacktrace():
+    """
+    Arrange/Act: Run `profiles edit invalid` subcommand.
+    Assert:  The output does not contain stacktrace.
+    """
+    runner: CliRunner = CliRunner()
+    with pytest.raises(ValueError):
+        result: Result = runner.invoke(
+            cli.cli, ["profiles", "show", "invalid"], catch_exceptions=False
+        )
+    result: Result = runner.invoke(
+        cli.cli,
+        ["profiles", "show", "invalid"],
+    )
+    assert isinstance(result.exception, ValueError)
+
+
 def test_list_profiles():
     runner: CliRunner = CliRunner()
     result: Result = runner.invoke(cli.cli, ["profiles", "list"])


### PR DESCRIPTION
Closes #135 

```sh
$ aiidalab-launch profiles edit invalid
Unexpected ValueError: Did not find profile with name 'invalid'.
Use verbose mode `aiidalab-launch --verbose` to see full stacktrace
```

I tried adding a test, but unfortunately the custom handler path is not exercised (see Codecov). Not very surprising that testing a custom exception handler in a testing framework does not work. :shrug: 

@csadorf this is ready for review.