### PR TITLE
Do not raise if Docker image cannot be pulled

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -327,17 +327,15 @@ async def _async_start(
 
     # Obtain image (either via pull or local).
     if pull:
-        try:
-            msg = (
-                f"Downloading image '{instance.profile.image}', this may take a while..."
-                if instance.image is None
-                else f"Downloading latest version of '{instance.profile.image}'..."
-            )
-            with spinner(msg):
-                instance.pull()
-        except RuntimeError as error:
-            raise click.ClickException(str(error))
-    elif instance.image is None:
+        msg = (
+            f"Downloading image '{instance.profile.image}', this may take a while..."
+            if instance.image is None
+            else f"Downloading latest version of '{instance.profile.image}'..."
+        )
+        with spinner(msg):
+            instance.pull()
+
+    if instance.image is None:
         raise click.ClickException(
             f"Unable to find image '{profile.image}'. "
             "Try to use '--pull' to pull the image prior to start."

--- a/aiidalab_launch/instance.py
+++ b/aiidalab_launch/instance.py
@@ -151,14 +151,15 @@ class AiidaLabInstance:
         if self.profile != Profile.from_container(self.container):
             yield "Profile configuration has changed."
 
-    def pull(self) -> docker.models.images.Image:
+    def pull(self) -> docker.models.images.Image | None:
         try:
             image = self.client.images.pull(self.profile.image)
             LOGGER.info(f"Pulled image: {image}")
             self._image = image
             return image
         except docker.errors.NotFound:
-            raise RuntimeError(f"Unable to pull image: {self.profile.image}")
+            LOGGER.warn(f"Unable to pull image: {self.profile.image}")
+            return None
 
     def _ensure_home_mount_exists(self) -> None:
         if self.profile.home_mount:

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -27,11 +27,13 @@ def test_instance_pull(instance, enable_docker_pull):
         .pull()
         .tags
     )
-    with pytest.raises(RuntimeError):
+    assert (
         replace(
             instance,
             profile=replace(instance.profile, image="hello-world:no-valid-tag"),
         ).pull()
+        is None
+    )
 
 
 def test_instance_unknown_image(instance, invalid_image_id):


### PR DESCRIPTION
Only emit a warning if Docker image is not found on Dockerhub.

This is useful for Docker images built locally, so that we do not always have to type "--no-pull"
when running `aiidalab-launch start`

Closes #153

I verifies locally that things still work as expected.