### PR TITLE
Don't show spinner with verbose output

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -92,7 +92,10 @@ def with_profile(cmd):
     "-v",
     "--verbose",
     count=True,
-    help="Provide this option to increase the output verbosity of the launcher.",
+    help=(
+        "Increase the output verbosity of the launcher. "
+        "Use '-vv' or '-vvv' for even more verbose output"
+    ),
 )
 @pass_app_state
 def cli(app_state, verbose):

--- a/aiidalab_launch/util.py
+++ b/aiidalab_launch/util.py
@@ -42,20 +42,24 @@ def spinner(
     """Display spinner only after an optional initial delay."""
 
     def spin() -> None:
-        if msg:
-            click.echo(f"{msg.rstrip()} ", nl=False, err=True)
 
         # Don't show spinner if verbose output is enabled
         level = logging.getLogger().getEffectiveLevel()
-        if level != logging.NOTSET and level < logging.ERROR:
-            stop.wait()
-            return
-
-        with click_spinner.spinner():  # type: ignore
-            stop.wait()
-        click.echo(
-            (final or "done.") if (completed.is_set() and msg) else " ", err=True
+        show_spinner = (
+            True if level == logging.NOTSET or level >= logging.ERROR else False
         )
+        if msg:
+            newline = not show_spinner
+            click.echo(f"{msg.rstrip()} ", nl=newline, err=True)
+
+        if show_spinner:
+            with click_spinner.spinner():  # type: ignore
+                stop.wait()
+            click.echo(
+                (final or "done.") if (completed.is_set() and msg) else " ", err=True
+            )
+        else:
+            stop.wait()
 
     stop = Event()
     completed = Event()

--- a/aiidalab_launch/util.py
+++ b/aiidalab_launch/util.py
@@ -37,7 +37,7 @@ SESSION = CachedSession(
 
 @contextmanager
 def spinner(
-    msg: Optional[str] = None, final: Optional[str] = None, delay: float = 0
+    msg: Optional[str] = None, final: Optional[str] = "done.", delay: float = 0
 ) -> Generator[None, None, None]:
     """Display spinner only after an optional initial delay."""
 
@@ -55,9 +55,7 @@ def spinner(
         if show_spinner:
             with click_spinner.spinner():  # type: ignore
                 stop.wait()
-            click.echo(
-                (final or "done.") if (completed.is_set() and msg) else " ", err=True
-            )
+            click.echo(final if (completed.is_set() and msg) else " ", err=True)
         else:
             stop.wait()
 

--- a/aiidalab_launch/util.py
+++ b/aiidalab_launch/util.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 import webbrowser
 from contextlib import contextmanager
@@ -43,6 +44,13 @@ def spinner(
     def spin() -> None:
         if msg:
             click.echo(f"{msg.rstrip()} ", nl=False, err=True)
+
+        # Don't show spinner if verbose output is enabled
+        level = logging.getLogger().getEffectiveLevel()
+        if level != 0 and level < 40:
+            stop.wait()
+            return
+
         with click_spinner.spinner():  # type: ignore
             stop.wait()
         click.echo(

--- a/aiidalab_launch/util.py
+++ b/aiidalab_launch/util.py
@@ -47,7 +47,7 @@ def spinner(
 
         # Don't show spinner if verbose output is enabled
         level = logging.getLogger().getEffectiveLevel()
-        if level != 0 and level < 40:
+        if level != logging.NOTSET and level < logging.ERROR:
             stop.wait()
             return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,8 @@ class TestInstanceLifecycle:
         assert result.exit_code == 0
 
         # Start instance again (blocking, should be no-op).
+        # Disabling verbose logging to test the spinner
+        caplog.set_level(logging.ERROR)
         runner: CliRunner = CliRunner()
         result: Result = runner.invoke(
             cli.cli, ["start", "--no-browser", "--no-pull", "--wait=300"]
@@ -225,6 +227,7 @@ class TestInstanceLifecycle:
         assert get_volume(instance.profile.conda_volume_name())
 
         # Start instance again – should be noop.
+        caplog.set_level(logging.DEBUG)
         result: Result = runner.invoke(
             cli.cli, ["start", "--no-browser", "--no-pull", "--wait=300"]
         )


### PR DESCRIPTION
When verbose output is enabled via the `-v` option, the spinner interferes with the extra output.

Closes #146