### PR TITLE
Trying to fix flaky test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         needs: [pre-commit]
 
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 10
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         needs: [pre-commit]
 
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 15
 
         strategy:
             fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 *.swp
+*.pyc
 .coverage
 __pycache__/
 build/

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -420,8 +420,6 @@ async def _async_start(
                 with spinner("Waiting for AiiDAlab instance to get ready..."):
                     echo_logs = asyncio.create_task(instance.echo_logs())
                     await asyncio.wait_for(instance.wait_for_services(), timeout=wait)
-                    echo_logs.cancel()
-                    LOGGER.debug("AiiDAlab instance ready.")
             except asyncio.TimeoutError:
                 raise click.ClickException(
                     f"AiiDAlab instance did not start up within the provided wait period ({wait})."
@@ -434,6 +432,11 @@ async def _async_start(
                     "and increase the output verbosity with "
                     "'aiidalab-launch -vvv start'."
                 )
+            else:
+                LOGGER.debug("AiiDAlab instance ready.")
+            finally:
+                echo_logs.cancel()
+
             LOGGER.debug("Preparing startup message.")
             msg_startup = (
                 MSG_STARTUP_SSH

--- a/aiidalab_launch/instance.py
+++ b/aiidalab_launch/instance.py
@@ -158,7 +158,7 @@ class AiidaLabInstance:
             self._image = image
             return image
         except docker.errors.NotFound:
-            LOGGER.warn(f"Unable to pull image: {self.profile.image}")
+            LOGGER.warning(f"Unable to pull image: {self.profile.image}")
             return None
 
     def _ensure_home_mount_exists(self) -> None:


### PR DESCRIPTION
I was trying to hunt down the issue behing the GHA CI timeout failures, reported in #163. 

The hypothesis was to see if issue #154 was behind this. See my last comment on #154 for details about my investigation. One think I noticed is that the asyncio `echo_logs` Task would not get cancelled if the container failed to start. I don't know if this is the reason for the test flakiness, but it is worth a shot I think.

EDIT: So this obviously did not help, but it still seems like a change worth doing. I've also decreased the timeout on GHA so that at least we're not wasting CI minutes.