### PR TITLE
Setting default app list in profiles empty

### DIFF
--- a/aiidalab_launch/profile.py
+++ b/aiidalab_launch/profile.py
@@ -65,7 +65,7 @@ def _get_aiidalab_default_apps(container: Container) -> list:
 class Profile:
     name: str = MAIN_PROFILE_NAME
     port: int | None = field(default_factory=_default_port)
-    default_apps: list[str] = field(default_factory=lambda: ["aiidalab-widgets-base"])
+    default_apps: list[str] = field(default_factory=lambda: [])
     system_user: str = "jovyan"
     image: str = _DEFAULT_IMAGE
     home_mount: str | None = None


### PR DESCRIPTION
First of all, we have the plan to not provide aiidalab-widgets-base as an app in the future. And we don't have a production release version for aiidalab-widgets-base, which will install the old version that is incompatible with the full-stack image. 
I think it makes more sense not to provide aiidalab-widgets-base as the default app as the default profile setting. It will cause the issue that when user follow the aiidalab-launch [instruction](https://aiidalab.readthedocs.io/en/latest/usage/index.html#aiidalab-launch) to using aiidalab first time, they will getting a broken container. 