### PR TITLE
Call echo_logs only when in DEBUG mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.10']
                 default-image:
                     - ''  # use the application default
                     - aiidalab/aiidalab-docker-stack:latest
@@ -73,7 +73,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.10']
 
         steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.8', '3.9', '3.10', '3.11']
                 default-image:
                     - ''  # use the application default
                     - aiidalab/aiidalab-docker-stack:latest
@@ -73,7 +73,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.8', '3.9', '3.10', '3.11']
 
         steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
             - name: Run tests
               run: |
-                  pytest -v --slow --default-image=${{ matrix.default-image }}
+                  pytest -sv --slow --default-image=${{ matrix.default-image }}
                   coverage xml
 
             - name: Upload coverage to Codecov

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -416,9 +416,11 @@ async def _async_start(
         raise click.ClickException(f"Unknown error occurred: {error}")
     else:
         if wait:
+            logging_level = logging.getLogger().getEffectiveLevel()
             try:
                 with spinner("Waiting for AiiDAlab instance to get ready..."):
-                    # echo_logs = asyncio.create_task(instance.echo_logs())
+                    if logging_level <= logging.DEBUG:
+                        echo_logs = asyncio.create_task(instance.echo_logs())
                     await asyncio.wait_for(instance.wait_for_services(), timeout=wait)
             except asyncio.TimeoutError:
                 raise click.ClickException(
@@ -434,8 +436,9 @@ async def _async_start(
                 )
             else:
                 LOGGER.debug("AiiDAlab instance ready.")
-            # finally:
-            #    echo_logs.cancel()
+            finally:
+                if logging_level <= logging.DEBUG:
+                    echo_logs.cancel()
 
             LOGGER.debug("Preparing startup message.")
             msg_startup = (

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -419,7 +419,7 @@ async def _async_start(
             logging_level = logging.getLogger().getEffectiveLevel()
             try:
                 with spinner("Waiting for AiiDAlab instance to get ready..."):
-                    if logging_level <= logging.DEBUG:
+                    if logging_level == logging.DEBUG:
                         echo_logs = asyncio.create_task(instance.echo_logs())
                     await asyncio.wait_for(instance.wait_for_services(), timeout=wait)
             except asyncio.TimeoutError:
@@ -437,7 +437,7 @@ async def _async_start(
             else:
                 LOGGER.debug("AiiDAlab instance ready.")
             finally:
-                if logging_level <= logging.DEBUG:
+                if logging_level == logging.DEBUG:
                     echo_logs.cancel()
 
             LOGGER.debug("Preparing startup message.")

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -418,7 +418,7 @@ async def _async_start(
         if wait:
             try:
                 with spinner("Waiting for AiiDAlab instance to get ready..."):
-                    echo_logs = asyncio.create_task(instance.echo_logs())
+                    # echo_logs = asyncio.create_task(instance.echo_logs())
                     await asyncio.wait_for(instance.wait_for_services(), timeout=wait)
             except asyncio.TimeoutError:
                 raise click.ClickException(
@@ -434,8 +434,8 @@ async def _async_start(
                 )
             else:
                 LOGGER.debug("AiiDAlab instance ready.")
-            finally:
-                echo_logs.cancel()
+            # finally:
+            #    echo_logs.cancel()
 
             LOGGER.debug("Preparing startup message.")
             msg_startup = (


### PR DESCRIPTION
The `echo_logs` function prints out the logs from the container (i.e. the output of `aiidalab-launch logs`) while the user waits for the container to start. However, logs are printed with `logging.DEBUG` so there's no point in calling this function unless this level of logging is enabled (via the `-vvv` cmdline parameter).

We have some indication that this function is problematic in #154 so calling it only when neccessary might help. We also have issues with flaky tests, #163. While the change here does not solve the flakiness (see failures [here](https://github.com/aiidalab/aiidalab-launch/actions/runs/4065691776/jobs/7000768652) and [here](https://github.com/aiidalab/aiidalab-launch/actions/runs/4065691776/jobs/7000768652)), it does seem to help since the test suite no longer times out, but actually fails in a reasonable amount of time. I haven't been able to pinpoint the reason for the failures, looking at the error messages it seems that the container fails to start randomly. So more investigation is needed but this seems to be a step in right direction at least.

