### PR TITLE
Update isort to fix pre-commit CI build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
           - id: setup-cfg-fmt
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
           - id: isort
             args: [--profile, black, --filter-files]


### PR DESCRIPTION
Pre-commit CI build started failing recently. Updating `isort` should fix it, same fix was applied in the aiida-core repo, see https://github.com/aiidalab/aiidalab-launch/pull/new/ci/update-isort for details.

Same issue is likely present in other AiiDAlab repos.