### PR TITLE
Trigger pull explictly if needed

### DIFF
--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -342,7 +342,7 @@ async def _async_start(
     else:
         # use local image
         msg = f"Using local image '{profile.image}'."
-    
+
     if instance.image is None:
         raise click.ClickException(
             f"Unable to find image '{profile.image}'. "

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -329,15 +329,20 @@ async def _async_start(
             )
 
     # Obtain image (either via pull or local).
-    if pull:
-        msg = (
-            f"Downloading image '{instance.profile.image}', this may take a while..."
-            if instance.image is None
-            else f"Downloading latest version of '{instance.profile.image}'..."
-        )
+    if instance.image is None:
+        # always pull if no image is available
+        msg = f"Downloading image '{profile.image}', this may take a while..."
         with spinner(msg):
             instance.pull()
-
+    elif pull:
+        # pull if explicitly requested and pull latest version of image
+        msg = f"Downloading latest version of '{profile.image}'..."
+        with spinner(msg):
+            instance.pull()
+    else:
+        # use local image
+        msg = f"Using local image '{profile.image}'."
+    
     if instance.image is None:
         raise click.ClickException(
             f"Unable to find image '{profile.image}'. "
@@ -499,7 +504,7 @@ async def _async_start(
 )
 @click.option(
     "--pull/--no-pull",
-    default=True,
+    default=False,
     help=(
         "Specify whether to pull the configured image prior to the first start "
         "of the container."


### PR DESCRIPTION
fixes #179 

The `pull` option was set as the default that will cause to download latest version when it is available, which is not desired as discussed in #179. In most case, user want to keep on using the image they pulled in the first place. New version image download is better happened when explicitly triggered by setting `pull`. 

This commit first to make `--no-pull` the default of `--pull/no-pull` option. The pull logic tweaks a bit that when the image does not exist, it will anyway trigger the pull. If the image exists, the `--pull` need to be set to trigger the pull.