### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: '3.10'
-            - uses: pre-commit/action@v2.0.0
+            - uses: pre-commit/action@v3.0.0
 
     test-package:
 
@@ -31,19 +31,19 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
                 default-image:
                     - ''  # use the application default
                     - aiidalab/aiidalab-docker-stack:latest
 
         steps:
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   submodules: true
 
-            - uses: actions/setup-python@v2
+            - uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -59,7 +59,7 @@ jobs:
                   coverage xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v2
+              uses: codecov/codecov-action@v3
               with:
                   flags: py-${{ matrix.python-version }}
 
@@ -77,12 +77,12 @@ jobs:
 
         steps:
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   submodules: true
 
-            - uses: actions/setup-python@v2
+            - uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
         steps:
 
@@ -88,7 +88,6 @@ jobs:
 
             - name: Install with pipx
               run: |
-                  which python
                   python -m pip install pipx
                   pipx install ${{ github.workspace }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
 
         steps:
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: '3.10'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,9 @@ pre_commit =
     pre-commit==3.5.0
 tests =
     pytest~=7.4.3
-    pytest-asyncio~=0.23.3
+    pytest-asyncio~=0.23.2
     pytest-cov~=4.1.0
-    responses~=0.24.1
+    responses~=0.23.1
 
 [flake8]
 ignore =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,10 +37,10 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    bumpver==2021.1114
+    bumpver==2023.1129
     dunamai==1.7.0
 pre_commit =
-    pre-commit==2.15.0
+    pre-commit==3.5.0
 tests =
     pytest==7.4.3
     pytest-asyncio==0.20.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ console_scripts =
 [options.extras_require]
 dev =
     bumpver==2023.1129
-    dunamai==1.7.0
+    dunamai==1.19.0
 pre_commit =
     pre-commit==3.5.0
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ dev =
 pre_commit =
     pre-commit==2.15.0
 tests =
-    pytest==7.2.1
+    pytest==7.4.3
     pytest-asyncio==0.20.3
     pytest-cov==4.0.0
     responses==0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 install_requires =
     click==8.1
     click-spinner==0.1.10
-    docker==5.0.3
+    docker==6.1.2
     packaging==21.3
     python-dotenv==0.19.1
     requests==2.26.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ pre_commit =
     pre-commit==3.5.0
 tests =
     pytest~=7.4.3
-    pytest-asyncio~=0.23.2
+    pytest-asyncio~=0.21.1
     pytest-cov~=4.1.0
     responses~=0.23.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,10 @@ dev =
 pre_commit =
     pre-commit==3.5.0
 tests =
-    pytest==7.4.3
-    pytest-asyncio==0.20.3
-    pytest-cov==4.0.0
-    responses==0.22.0
+    pytest~=7.4.3
+    pytest-asyncio~=0.23.3
+    pytest-cov~=4.1.0
+    responses~=0.24.1
 
 [flake8]
 ignore =


### PR DESCRIPTION
The blocker here was the `docker` Python API dependency, old version relied on `distutils` package that was removed in Python 3.12. I also took this opportunity to upgrade test dependencies and some Github actions.

Closes #194 