### PR TITLE
Update dependencies: docker -> 7.0.0 and tabulate -> 0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,7 @@ on:
 
 jobs:
 
-    pre-commit:
-
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: '3.11'
-            - uses: pre-commit/action@v3.0.0
-
     test-package:
-
-        needs: [pre-commit]
 
         runs-on: ubuntu-latest
         timeout-minutes: 15
@@ -64,8 +50,6 @@ jobs:
                   flags: py-${{ matrix.python-version }}
 
     test-installation-with-pipx:
-
-        needs: [pre-commit]
 
         runs-on: ubuntu-latest
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.10
+            - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.10'
+                  python-version: '3.11'
             - uses: pre-commit/action@v3.0.0
 
     test-package:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                   --outdir dist/
 
             - name: Upload distribution artifact
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: dist/
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               name: Download distribution artifact
               with:
                   name: release

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This package follows the Python compatibility and deprecation schedule specified
 
 ### Setting up a development environment
 
-To develop this package, first clone it and then install the development dependencies with `pip install -e '.[dev,pre_commit]'`.
+To develop this package, first clone it and then install the development dependencies with `pip install -e '.[dev]'`.
 We recommend to install the [pre-commit](https://pre-commit.com/) hooks to avoid unnecessary iterations when pushing new changes.
 To install the pre-commit hooks, switch into the repository root directly and execute:
 ```console

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,12 @@ packages = find:
 install_requires =
     click==8.1
     click-spinner==0.1.10
-    docker==6.1.2
+    docker==7.0.0
     packaging==21.3
     python-dotenv==0.19.1
     requests==2.26.0
     requests-cache==0.9.1
-    tabulate==0.8.9
+    tabulate==0.9.0
     toml==0.10.2
 python_requires = >=3.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ console_scripts =
 dev =
     bumpver==2023.1129
     dunamai==1.19.0
-pre_commit =
     pre-commit==3.5.0
 tests =
     pytest~=7.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
     click-spinner==0.1.10
     docker==7.0.0
     packaging==21.3
-    python-dotenv==0.19.1
     requests==2.26.0
     requests-cache==0.9.1
     tabulate==0.9.0


### PR DESCRIPTION
Main goal here is to upgrade to `docker-py==7.0.0` which contains a bugfix that I ran into while testing locally with Python 3.12:
https://github.com/docker/docker-py/issues/3151

Looks like the bug was introduced in version `6.2` which we bumped to in #194 but did not release yet so no users should be affected. 

Depends on #201 