### PR TITLE
Fix flake8 violation

### DIFF
--- a/aiidalab_launch/profile.py
+++ b/aiidalab_launch/profile.py
@@ -88,7 +88,7 @@ class Profile:
 
         # Normalize extra mount mode to be "rw" by default
         # so that we match Docker default but are explicit.
-        for extra_mount in self.extra_mounts:
+        for extra_mount in self.extra_mounts.copy():
             self.parse_extra_mount(extra_mount)
             if len(extra_mount.split(":")) == 2:
                 self.extra_mounts.remove(extra_mount)


### PR DESCRIPTION
flake8 currently fails on main (I have no idea why the CI is green on the latest commit though, very strange). This is the error:

```python
aiidalab_launch/profile.py:94:17: B038 editing a loop's mutable iterable often leads to unexpected results/bugs
                self.extra_mounts.remove(extra_mount)
```