### PR TITLE
Use ruff instead of flake8, isort, black and pyupgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
                 default-image:
-                    - ''  # use the application default
-                    - aiidalab/aiidalab-docker-stack:latest  # This is the old stack
+                    - ''   # use the application default
+                    - aiidalab/aiidalab-docker-stack:latest   # This is the old stack
 
         steps:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,20 +22,13 @@ repos:
       hooks:
           - id: check-manifest
 
-    - repo: https://github.com/psf/black
-      rev: 23.12.1
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.2.1
       hooks:
-          - id: black
+          - id: ruff-format
             exclude: ^docs/
-
-    - repo: https://github.com/PyCQA/flake8
-      rev: 6.1.0
-      hooks:
-          - id: flake8
-            args: [--count, --show-source, --statistics]
-            additional_dependencies:
-                - flake8-bugbear
-                - flake8-unused-arguments==0.0.9
+          - id: ruff
+            args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.8.0
@@ -52,19 +45,7 @@ repos:
       hooks:
           - id: setup-cfg-fmt
 
-    - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            args: [--profile, black, --filter-files]
-
     - repo: https://github.com/sirosen/check-jsonschema
       rev: 0.27.3
       hooks:
           - id: check-github-workflows
-
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v3.15.0
-      hooks:
-          - id: pyupgrade
-            args: [--py38-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
                 - types-requests
                 - types-tabulate
                 - types-toml
+
+    - repo: https://github.com/mgedmin/check-manifest
+      rev: '0.49'
+      hooks:
+          - id: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
 
+    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+      rev: 0.2.3
+      hooks:
+          - id: yamlfmt
+
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.2.1
       hooks:
@@ -19,11 +24,6 @@ repos:
             exclude: ^docs/
           - id: ruff
             args: [--fix, --exit-non-zero-on-fix, --show-fixes]
-
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
 
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.8.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,20 +7,10 @@ repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.5.0
       hooks:
-          - id: check-json
           - id: check-yaml
+          - id: check-toml
           - id: end-of-file-fixer
           - id: trailing-whitespace
-
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
-
-    - repo: https://github.com/mgedmin/check-manifest
-      rev: '0.49'
-      hooks:
-          - id: check-manifest
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.2.1
@@ -29,6 +19,11 @@ repos:
             exclude: ^docs/
           - id: ruff
             args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+
+    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+      rev: 0.2.3
+      hooks:
+          - id: yamlfmt
 
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.8.0
@@ -39,13 +34,3 @@ repos:
                 - types-requests
                 - types-tabulate
                 - types-toml
-
-    - repo: https://github.com/asottile/setup-cfg-fmt
-      rev: v2.5.0
-      hooks:
-          - id: setup-cfg-fmt
-
-    - repo: https://github.com/sirosen/check-jsonschema
-      rev: 0.27.3
-      hooks:
-          - id: check-github-workflows

--- a/aiidalab_launch/__main__.py
+++ b/aiidalab_launch/__main__.py
@@ -68,7 +68,7 @@ LOGGING_LEVELS = {
 pass_app_state = click.make_pass_decorator(ApplicationState, ensure=True)
 
 
-def exception_handler(exception_type, exception, traceback):  # noqa: U100
+def exception_handler(exception_type, exception, _traceback):
     click.echo(f"Unexpected {exception_type.__name__}: {exception}", err=True)
     click.echo(
         "Use verbose mode `aiidalab-launch --verbose` to see full stack trace", err=True
@@ -76,7 +76,7 @@ def exception_handler(exception_type, exception, traceback):  # noqa: U100
 
 
 def with_profile(cmd):
-    def callback(ctx, param, value):  # noqa: U100
+    def callback(ctx, _param, value):
         app_state = ctx.ensure_object(ApplicationState)
         name = value or app_state.config.default_profile
         LOGGER.info(f"Using profile: {name}")
@@ -320,7 +320,7 @@ async def _async_start(
     if not force:
         conflict = False
         with spinner("Check for potential conflicts...", delay=0.1):
-            async for p in _find_mount_point_conflict(
+            async for _p in _find_mount_point_conflict(
                 app_state.docker_client,
                 profile,
                 app_state.config.profiles,

--- a/aiidalab_launch/util.py
+++ b/aiidalab_launch/util.py
@@ -172,15 +172,10 @@ def confirm_with_value(value: str, text: str, abort: bool = False) -> bool:
 def get_docker_mount(
     container: docker.models.containers.Container, destination: PurePosixPath
 ) -> docker.types.Mount:
-    try:
-        mount = [
-            mount
-            for mount in container.attrs["Mounts"]
-            if mount["Destination"] == str(destination)
-        ][0]
-    except IndexError:
-        raise ValueError(f"No mount point for {destination}.")
-    return mount
+    for mount in container.attrs["Mounts"]:
+        if mount["Destination"] == str(destination):
+            return mount
+    raise ValueError(f"No mount point for {destination}.")
 
 
 def is_volume_readonly(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,5 @@
 # TODO: Move entire setup.cfg to pyproject.toml
 
-[build-system]
-build-backend = "setuptools.build_meta"
-# Version 64.0.0 is needed for editable installs without setup.py file
-# https://setuptools.pypa.io/en/latest/references/keywords.html
-requires = [
-  "setuptools>=64.0.0",
-  "wheel"
-]
-
 [tool.ruff]
 line-length = 88
 show-fixes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,33 @@
 # TODO: Move entire setup.cfg to pyproject.toml
-#
+
 [build-system]
+build-backend = "setuptools.build_meta"
 # Version 64.0.0 is needed for editable installs without setup.py file
 # https://setuptools.pypa.io/en/latest/references/keywords.html
 requires = [
-    "setuptools>=64.0.0",
-    "wheel"
+  "setuptools>=64.0.0",
+  "wheel"
 ]
-build-backend = "setuptools.build_meta"
-
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
 show-fixes = true
+target-version = "py38"
 
 [tool.ruff.lint]
 # TODO: Fixup all instances of B904 and enable this rule
 ignore = ["E501", "B904"]
 select = [
-    "ARG",  # flake8-unused-arguments
-    "B",    # flake8-bugbear
-    "E",    # pycodestyle
-    "F",    # pyflake
-    "I",    # isort
-    "PLE",  # pylint error rules
-    "PLW",  # pylint warning rules
-    "PLC",  # pylint convention rules
-    "RUF",  # ruff-specific rules
-    "UP",   # pyupgrade
+  "ARG",  # flake8-unused-arguments
+  "B",  # flake8-bugbear
+  "E",  # pycodestyle
+  "F",  # pyflake
+  "I",  # isort
+  "PLE",  # pylint error rules
+  "PLW",  # pylint warning rules
+  "PLC",  # pylint convention rules
+  "RUF",  # ruff-specific rules
+  "UP"  # pyupgrade
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+# TODO: Move entire setup.cfg to pyproject.toml
+#
+[build-system]
+# Version 64.0.0 is needed for editable installs without setup.py file
+# https://setuptools.pypa.io/en/latest/references/keywords.html
+requires = [
+    "setuptools>=64.0.0",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+
+[tool.ruff]
+line-length = 88
+target-version = "py38"
+show-fixes = true
+
+[tool.ruff.lint]
+# TODO: Fixup all instances of B904 and enable this rule
+ignore = ["E501", "B904"]
+select = [
+    "ARG",  # flake8-unused-arguments
+    "B",    # flake8-bugbear
+    "E",    # pycodestyle
+    "F",    # pyflake
+    "I",    # isort
+    "PLE",  # pylint error rules
+    "PLW",  # pylint warning rules
+    "PLC",  # pylint convention rules
+    "RUF",  # ruff-specific rules
+    "UP",   # pyupgrade
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ARG001"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,14 +45,6 @@ tests =
     pytest-cov~=4.1.0
     responses~=0.23.1
 
-[flake8]
-ignore =
-    E501
-    W503
-    E203
-per-file-ignores =
-    tests/*: U100, U101
-
 [mypy]
 warn_unused_configs = True
 disallow_untyped_calls = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ def test_add_remove_profile():
     result: Result = runner.invoke(cli.cli, ["profile", "list"])
     assert "new-profile" not in result.output
 
-    # Remove new-profile (again – should fail)
+    # Remove new-profile (again - should fail)
     result: Result = runner.invoke(
         cli.cli, ["profile", "remove", "new-profile"], input="y\n"
     )
@@ -251,7 +251,7 @@ class TestInstanceLifecycle:
         assert get_volume(instance.profile.home_mount)
         assert get_volume(instance.profile.conda_volume_name())
 
-        # Start instance again – should be noop.
+        # Start instance again - should be noop.
         caplog.set_level(logging.DEBUG)
         result: Result = runner.invoke(
             cli.cli, ["start", "--no-browser", "--no-pull", "--wait=300"]


### PR DESCRIPTION
aiida-core recently switched to ruff, and I've been using it for my app for some time. IMO we should consider slowly switching AiiDAlab repos as well. @unkcpz @yakutovicha LMK what you think. 

I've enabled a couple more rules than there were before, based on my judgment and previous experience. More might be useful, but this is a reasonable start IMO.

I've also removed a couple of hooks that did not seem as useful, now that the codebase and its configuration is quite stable. But I am happy to revert.